### PR TITLE
Fix deprecated setting properties on Sanic version 21.12+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ Example
 
 
     app = Sanic(__name__)
-    CustomExtension()  # available via `app.custom` or `app.extensions['custom']`
-    app.custom.hello('world')  # Hello, world!
+    CustomExtension(app)  # available via `app.custom` or `app.extensions['custom']`
+    app.ctx.custom.hello('world')  #
 
 License
 =======

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Example
 
     app = Sanic(__name__)
     CustomExtension(app)  # available via `app.custom` or `app.extensions['custom']`
-    app.ctx.custom.hello('world')  #
+    app.ctx.custom.hello('world')  # Hello, world!
 
 License
 =======

--- a/sanic_base_ext/__init__.py
+++ b/sanic_base_ext/__init__.py
@@ -17,13 +17,13 @@ class BaseExtension(object):
             self.init_app(app, *args, **kwargs)
 
     def _register_extension(self, app, *args, **kwargs):
-        if not hasattr(app, 'extensions'):
-            setattr(app, 'extensions', {})
+        if not hasattr(app.ctx, 'extensions'):
+            setattr(app.ctx, 'extensions', {})
 
-        app.extensions[self.extension_name] = self
+        app.ctx.extensions[self.extension_name] = self
 
     def init_app(self, app, *args, **kwargs):
-        setattr(app, self.app_attribute, self)
+        setattr(app.ctx, self.app_attribute, self)
 
     def get_from_app_config(self, app, parameter, default=None):
         return getattr(app.config, parameter, default)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],


### PR DESCRIPTION
see https://sanic.dev/en/guide/release-notes/v21.12.html#strict-application-and-blueprint-properties

with sanic version 21.12+
usage change from `app.custom` to `app.ctx.custom`